### PR TITLE
FS - switches to the webpack FS implementation to track the outputs

### DIFF
--- a/change/heap-sampling-webpack-plugin-bd894023-ce8d-4c6f-8bcc-a704457ec142.json
+++ b/change/heap-sampling-webpack-plugin-bd894023-ce8d-4c6f-8bcc-a704457ec142.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "changes node fs to the Webpack provided fs to track outputs",
+  "packageName": "heap-sampling-webpack-plugin",
+  "email": "kchau@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/src/HeapSamplingPlugin.ts
+++ b/src/HeapSamplingPlugin.ts
@@ -50,7 +50,7 @@ export class HeapSamplingPlugin {
 
       if (/\/|\\/.test(outputPath)) {
         const dirPath = path.dirname(outputPath);
-        mkdirpSync(dirPath, { recursive: true });
+        mkdirpSync(fs, dirPath);
       }
 
       await writeFile(this.options.outputPath, JSON.stringify(profile));


### PR DESCRIPTION
Inspired by the webpack.debug.ProfilingPlugin - and prompted by @markjm, switching to using the webpack fs