### PR TITLE
Update README.md with all options available

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const HeapSamplingPlugin = require("heap-sampling-webpack-plugin");
 
 module.exports = {
   plugins: [
-    new HeapSamplingPlugin();
+    new HeapSamplingPlugin({ heapProfile: true );
   ]
 }
 ```
@@ -22,6 +22,9 @@ You may want to specify an option with this plugin:
 
 ```js
 new HeapSamplingPlugin({
-  outputPath: "/some/place/my.heapprofile"
+  outputPath: "/some/place/my.heapprofile",
+  checkPeakMemory: true,
+  checkPeakMemoryInterval: 30,
+  heapProfile: true
 })
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ const HeapSamplingPlugin = require("heap-sampling-webpack-plugin");
 
 module.exports = {
   plugins: [
-    new HeapSamplingPlugin({ heapProfile: true );
+    new HeapSamplingPlugin({ heapProfile: true })
   ]
 }
 ```


### PR DESCRIPTION
Show all the options in the example and update the first example.

The `heapProfile` looks like it needs to be specified for the plugin to be enabled.

It also looks `checkPeakMemory` and `heapProfile` are independent options so I set both of them to `true` in the example.